### PR TITLE
Add functionality to view assigned policies of a client, delete them and delete policies itself.

### DIFF
--- a/src/main/java/longtimenosee/commons/core/Messages.java
+++ b/src/main/java/longtimenosee/commons/core/Messages.java
@@ -8,7 +8,6 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX = "The client index provided is invalid";
     public static final String MESSAGE_INVALID_POLICY_DISPLAYED_INDEX = "The policy index provided is invalid";
     public static final String MESSAGE_INVALID_EVENT_DISPLAYED_INDEX = "The event index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";

--- a/src/main/java/longtimenosee/logic/commands/AddCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/AddCommand.java
@@ -19,7 +19,7 @@ import longtimenosee.model.person.Person;
  */
 public class AddCommand extends Command {
 
-    public static final String COMMAND_WORD = "add";
+    public static final String COMMAND_WORD = "addContact";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the address book. "
             + "Parameters: "

--- a/src/main/java/longtimenosee/logic/commands/CommandResult.java
+++ b/src/main/java/longtimenosee/logic/commands/CommandResult.java
@@ -21,7 +21,7 @@ public class CommandResult {
     private final boolean showPolicy;
 
     /** The application should display clients. */
-    private final boolean showClients;
+    private final boolean showPerson;
 
 
     /** The application should display events. */
@@ -34,14 +34,14 @@ public class CommandResult {
      * Constructs a {@code CommandResult} with the specified fields.
      */
     public CommandResult(String feedbackToUser, boolean showHelp, boolean exit,
-                         boolean showPolicy, boolean showClient, boolean showEvent, boolean showIncome) {
+                         boolean showPolicy, boolean showPerson, boolean showEvent, boolean showIncome) {
 
 
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
         this.showPolicy = showPolicy;
-        this.showClients = showClient;
+        this.showPerson = showPerson;
         this.showEvent = showEvent;
         this.showIncome = showIncome;
 
@@ -73,8 +73,8 @@ public class CommandResult {
         return showPolicy;
     }
 
-    public boolean isShowClient() {
-        return showClients;
+    public boolean isShowPerson() {
+        return showPerson;
     }
     public boolean isShowIncome() {
         return showIncome;
@@ -106,7 +106,7 @@ public class CommandResult {
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit, showPolicy, showClients, showEvent, showIncome);
+        return Objects.hash(feedbackToUser, showHelp, exit, showPolicy, showPerson, showEvent, showIncome);
     }
 
 }

--- a/src/main/java/longtimenosee/logic/commands/DeleteCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/DeleteCommand.java
@@ -15,7 +15,7 @@ import longtimenosee.model.person.Person;
  */
 public class DeleteCommand extends Command {
 
-    public static final String COMMAND_WORD = "delete";
+    public static final String COMMAND_WORD = "deleteContact";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the index number used in the displayed person list.\n"

--- a/src/main/java/longtimenosee/logic/commands/EditCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/EditCommand.java
@@ -35,7 +35,7 @@ import longtimenosee.model.tag.Tag;
  */
 public class EditCommand extends Command {
 
-    public static final String COMMAND_WORD = "editPerson";
+    public static final String COMMAND_WORD = "editContact";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "

--- a/src/main/java/longtimenosee/logic/commands/EditCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/EditCommand.java
@@ -35,7 +35,7 @@ import longtimenosee.model.tag.Tag;
  */
 public class EditCommand extends Command {
 
-    public static final String COMMAND_WORD = "edit";
+    public static final String COMMAND_WORD = "editPerson";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "

--- a/src/main/java/longtimenosee/logic/commands/FindCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/FindCommand.java
@@ -14,7 +14,7 @@ import longtimenosee.model.person.Person;
  */
 public class FindCommand extends Command {
 
-    public static final String COMMAND_WORD = "find";
+    public static final String COMMAND_WORD = "findContact";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons that match the given metrics and "
             + "and displays them as a list with index numbers.\n"

--- a/src/main/java/longtimenosee/logic/commands/ListCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/ListCommand.java
@@ -10,9 +10,9 @@ import longtimenosee.model.Model;
  */
 public class ListCommand extends Command {
 
-    public static final String COMMAND_WORD = "list";
+    public static final String COMMAND_WORD = "listContacts";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SUCCESS = "Listed all contacts";
 
 
     @Override

--- a/src/main/java/longtimenosee/logic/commands/ListEventsCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/ListEventsCommand.java
@@ -10,7 +10,7 @@ import longtimenosee.model.Model;
  */
 public class ListEventsCommand extends Command {
 
-    public static final String COMMAND_WORD = "events";
+    public static final String COMMAND_WORD = "listEvents";
 
     public static final String MESSAGE_SUCCESS = "Listed all events";
 

--- a/src/main/java/longtimenosee/logic/commands/PersonCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/PersonCommand.java
@@ -7,7 +7,7 @@ import longtimenosee.model.Model;
  */
 public class PersonCommand extends Command {
 
-    public static final String COMMAND_WORD = "showClient";
+    public static final String COMMAND_WORD = "clients";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
             + "Example: " + COMMAND_WORD;

--- a/src/main/java/longtimenosee/logic/commands/PersonCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/PersonCommand.java
@@ -7,12 +7,12 @@ import longtimenosee.model.Model;
  */
 public class PersonCommand extends Command {
 
-    public static final String COMMAND_WORD = "clients";
+    public static final String COMMAND_WORD = "contacts";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String MESSAGE_SUCCESS = "Listed all clients";
+    public static final String MESSAGE_SUCCESS = "Listed all contacts";
 
 
     @Override

--- a/src/main/java/longtimenosee/logic/commands/PolicyAssignCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/PolicyAssignCommand.java
@@ -81,7 +81,7 @@ public class PolicyAssignCommand extends Command {
         //model.deletePerson(personToPin); optional because we don't alter the list
         return new CommandResult(String.format(success
                 ? MESSAGE_ASSIGN_POLICY_SUCCESS : MESSAGE_ASSIGN_PERSON_DUPLICATE, policyToAdd, personToAddTo),
-                false, true, false, false, false, false);
+                false, false, false, true, false, false);
     }
 
 }

--- a/src/main/java/longtimenosee/logic/commands/PolicyAssignedListCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/PolicyAssignedListCommand.java
@@ -1,24 +1,54 @@
 package longtimenosee.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static longtimenosee.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import java.util.List;
+import java.util.Set;
+
+import longtimenosee.commons.core.Messages;
+import longtimenosee.commons.core.index.Index;
+import longtimenosee.logic.commands.exceptions.CommandException;
 import longtimenosee.model.Model;
+import longtimenosee.model.person.Person;
+import longtimenosee.model.policy.AssignedPolicy;
 
 /**
  * Lists all persons in the address book to the user.
  */
-public class ListCommand extends Command {
+public class PolicyAssignedListCommand extends Command {
 
-    public static final String COMMAND_WORD = "list";
+    public static final String COMMAND_WORD = "listAssigned";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SUCCESS = "Listed all assigned policies for %1$s";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows a list of assigned policies for a given person "
+            + "Parameters: INDEX of person (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    private final Index personIndex;
+
+    public PolicyAssignedListCommand(Index personIndex) {
+        this.personIndex = personIndex;
+    }
 
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model) throws CommandException {
+
+        String display = "";
+
         requireNonNull(model);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS, false, true, false);
+        List<Person> filteredPersonList = model.getFilteredPersonList();
+        if (personIndex.getZeroBased() >= filteredPersonList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
+        }
+        Person personToList = filteredPersonList.get(personIndex.getZeroBased());
+        Set<AssignedPolicy> assignedPolicySet = personToList.getAssignedPolicies();
+        for (AssignedPolicy assignedPolicy: assignedPolicySet) {
+            display += assignedPolicy + "\n";
+        }
+
+        return new CommandResult(String.format(MESSAGE_SUCCESS, personToList.getName()) + "\n" + display,
+                false, true, false);
     }
 }

--- a/src/main/java/longtimenosee/logic/commands/PolicyAssignedListCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/PolicyAssignedListCommand.java
@@ -1,0 +1,24 @@
+package longtimenosee.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static longtimenosee.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import longtimenosee.model.Model;
+
+/**
+ * Lists all persons in the address book to the user.
+ */
+public class ListCommand extends Command {
+
+    public static final String COMMAND_WORD = "list";
+
+    public static final String MESSAGE_SUCCESS = "Listed all persons";
+
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(MESSAGE_SUCCESS, false, true, false);
+    }
+}

--- a/src/main/java/longtimenosee/logic/commands/PolicyCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/PolicyCommand.java
@@ -9,7 +9,7 @@ import longtimenosee.model.Model;
  */
 public class PolicyCommand extends Command {
 
-    public static final String COMMAND_WORD = "showPolicy";
+    public static final String COMMAND_WORD = "policies";
 
     public static final String MESSAGE_SUCCESS = "Listed all policies";
 

--- a/src/main/java/longtimenosee/logic/commands/PolicyDeleteAssignedCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/PolicyDeleteAssignedCommand.java
@@ -1,0 +1,87 @@
+package longtimenosee.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static longtimenosee.logic.parser.CliSyntax.PREFIX_END;
+import static longtimenosee.logic.parser.CliSyntax.PREFIX_PREMIUM;
+import static longtimenosee.logic.parser.CliSyntax.PREFIX_START;
+
+import java.util.List;
+
+import longtimenosee.commons.core.Messages;
+import longtimenosee.commons.core.index.Index;
+import longtimenosee.logic.commands.exceptions.CommandException;
+import longtimenosee.model.Model;
+import longtimenosee.model.person.Person;
+import longtimenosee.model.policy.AssignedPolicy;
+import longtimenosee.model.policy.Policy;
+import longtimenosee.model.policy.PolicyDate;
+import longtimenosee.model.policy.Premium;
+
+
+/**
+ * Policy assign command, used to assign a policy to a client.
+ */
+public class PolicyAssignCommand extends Command {
+
+    public static final String COMMAND_WORD = "assign";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": assigns a policy to a client. "
+            + "Parameters: "
+            + "(Index of client) "
+            + "(Index of policy) "
+            + PREFIX_PREMIUM + "200.00 "
+            + PREFIX_START + "2020-12-10 "
+            + PREFIX_END + "2021-12-15";
+
+    public static final String MESSAGE_ASSIGN_POLICY_SUCCESS = "Assigned policy %1$s to Client: %2$s";
+
+    public static final String MESSAGE_ASSIGN_PERSON_DUPLICATE = "Policy has already been assigned to Client: %2$s";
+
+    private final Index targetPersonIndex;
+    private final Index targetPolicyIndex;
+    private final Premium premium;
+    private final PolicyDate startDate;
+    private final PolicyDate endDate;
+
+    /**
+     * Constructor for PolicyAssignCommand.
+     * @param targetPersonIndex
+     * @param targetPolicyIndex
+     * @param premium
+     * @param startDate
+     * @param endDate
+     */
+    public PolicyAssignCommand(Index targetPersonIndex, Index targetPolicyIndex, Premium premium,
+                               PolicyDate startDate, PolicyDate endDate) {
+        this.targetPersonIndex = targetPersonIndex;
+        this.targetPolicyIndex = targetPolicyIndex;
+        this.premium = premium;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownPersonList = model.getFilteredPersonList();
+        List<Policy> lastShownPolicyList = model.getFilteredPolicyList();
+
+        if (targetPersonIndex.getZeroBased() >= lastShownPersonList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        if (targetPolicyIndex.getZeroBased() >= lastShownPolicyList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
+        }
+
+        Person personToAddTo = lastShownPersonList.get(targetPersonIndex.getZeroBased()); //gets the person to be added
+        Policy policyToAdd = lastShownPolicyList.get(targetPolicyIndex.getZeroBased()); //gets the policy to be added
+        boolean success = personToAddTo.addPolicy(new AssignedPolicy(
+                policyToAdd, premium, startDate, endDate)); //add the policy
+        //model.deletePerson(personToPin); optional because we don't alter the list
+        return new CommandResult(String.format(success
+                ? MESSAGE_ASSIGN_POLICY_SUCCESS : MESSAGE_ASSIGN_PERSON_DUPLICATE, policyToAdd, personToAddTo),
+                false, true, false, false, false, false);
+    }
+
+}

--- a/src/main/java/longtimenosee/logic/commands/PolicyDeleteAssignedCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/PolicyDeleteAssignedCommand.java
@@ -58,9 +58,9 @@ public class PolicyDeleteAssignedCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
         }
 
-        AssignedPolicy[] AssignedPolicyArray = new AssignedPolicy[assignedPolicySet.size()];
-        assignedPolicySet.toArray(AssignedPolicyArray);
-        AssignedPolicy assignedPolicy = AssignedPolicyArray[targetPolicyIndex.getZeroBased()];
+        AssignedPolicy[] assignedPolicyArray = new AssignedPolicy[assignedPolicySet.size()];
+        assignedPolicySet.toArray(assignedPolicyArray);
+        AssignedPolicy assignedPolicy = assignedPolicyArray[targetPolicyIndex.getZeroBased()];
         boolean success = personToDeleteFrom.removePolicy(assignedPolicy);
         return new CommandResult(String.format(success
                 ? MESSAGE_ASSIGN_POLICY_SUCCESS : MESSAGE_ASSIGN_POLICY_FAIL, assignedPolicy, personToDeleteFrom),

--- a/src/main/java/longtimenosee/logic/commands/PolicyDeleteCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/PolicyDeleteCommand.java
@@ -3,11 +3,14 @@ package longtimenosee.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.List;
+import java.util.Set;
 
 import longtimenosee.commons.core.Messages;
 import longtimenosee.commons.core.index.Index;
 import longtimenosee.logic.commands.exceptions.CommandException;
 import longtimenosee.model.Model;
+import longtimenosee.model.person.Person;
+import longtimenosee.model.policy.AssignedPolicy;
 import longtimenosee.model.policy.Policy;
 
 
@@ -35,6 +38,7 @@ public class PolicyDeleteCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Policy> lastShownList = model.getFilteredPolicyList();
+        List<Person> personList = model.getAddressBook().getPersonList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_POLICY_DISPLAYED_INDEX);
@@ -42,6 +46,14 @@ public class PolicyDeleteCommand extends Command {
 
         Policy policyToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePolicy(policyToDelete);
+        for (Person person:personList) {
+            Set<AssignedPolicy> assignedPolicies = person.getAssignedPolicies();
+            for (AssignedPolicy assignedPolicy:assignedPolicies) {
+                if (assignedPolicy.isSamePolicy(policyToDelete)) {
+                    person.removePolicy(assignedPolicy);
+                }
+            }
+        }
         return new CommandResult(String.format(MESSAGE_DELETE_POLICY_SUCCESS, policyToDelete),
                 true, false, false);
     }

--- a/src/main/java/longtimenosee/logic/commands/PolicyListCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/PolicyListCommand.java
@@ -10,7 +10,7 @@ import longtimenosee.model.Model;
  */
 public class PolicyListCommand extends Command {
 
-    public static final String COMMAND_WORD = "policyList";
+    public static final String COMMAND_WORD = "listPolicy";
 
     public static final String MESSAGE_SUCCESS = "Listed all policies";
 

--- a/src/main/java/longtimenosee/logic/commands/PolicyListCommand.java
+++ b/src/main/java/longtimenosee/logic/commands/PolicyListCommand.java
@@ -10,7 +10,7 @@ import longtimenosee.model.Model;
  */
 public class PolicyListCommand extends Command {
 
-    public static final String COMMAND_WORD = "listPolicy";
+    public static final String COMMAND_WORD = "listPolicies";
 
     public static final String MESSAGE_SUCCESS = "Listed all policies";
 

--- a/src/main/java/longtimenosee/logic/parser/AddressBookParser.java
+++ b/src/main/java/longtimenosee/logic/parser/AddressBookParser.java
@@ -23,7 +23,9 @@ import longtimenosee.logic.commands.PersonCommand;
 import longtimenosee.logic.commands.PinCommand;
 import longtimenosee.logic.commands.PolicyAddCommand;
 import longtimenosee.logic.commands.PolicyAssignCommand;
+import longtimenosee.logic.commands.PolicyAssignedListCommand;
 import longtimenosee.logic.commands.PolicyCommand;
+import longtimenosee.logic.commands.PolicyDeleteAssignedCommand;
 import longtimenosee.logic.commands.PolicyDeleteCommand;
 import longtimenosee.logic.commands.PolicyListCommand;
 import longtimenosee.logic.commands.SortCommand;
@@ -116,13 +118,21 @@ public class AddressBookParser {
         case PolicyAssignCommand.COMMAND_WORD:
             return new PolicyAssignCommandParser().parse(arguments);
 
+        case PolicyAssignedListCommand.COMMAND_WORD:
+            return new PolicyAssignedListCommandParser().parse(arguments);
+
+        case PolicyDeleteAssignedCommand.COMMAND_WORD:
+            return new PolicyAssignedDeleteCommandParser().parse(arguments);
+
         case AddEventCommand.COMMAND_WORD:
             return new AddEventCommandParser().parse(arguments);
 
         case DeleteEventCommand.COMMAND_WORD:
             return new DeleteEventCommandParser().parse(arguments);
+
         case ListEventsCommand.COMMAND_WORD:
             return new ListEventsCommand();
+
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }

--- a/src/main/java/longtimenosee/logic/parser/PolicyAssignedDeleteCommandParser.java
+++ b/src/main/java/longtimenosee/logic/parser/PolicyAssignedDeleteCommandParser.java
@@ -1,0 +1,29 @@
+package longtimenosee.logic.parser;
+
+import static longtimenosee.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import longtimenosee.commons.core.index.Index;
+import longtimenosee.logic.commands.PolicyDeleteCommand;
+import longtimenosee.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new PolicyDeleteCommand object
+ */
+public class PolicyDeleteCommandParser implements Parser<PolicyDeleteCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the PolicyDeleteCommand
+     * and returns a DeleteCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public PolicyDeleteCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new PolicyDeleteCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PolicyDeleteCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/longtimenosee/logic/parser/PolicyAssignedDeleteCommandParser.java
+++ b/src/main/java/longtimenosee/logic/parser/PolicyAssignedDeleteCommandParser.java
@@ -3,27 +3,34 @@ package longtimenosee.logic.parser;
 import static longtimenosee.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import longtimenosee.commons.core.index.Index;
-import longtimenosee.logic.commands.PolicyDeleteCommand;
+import longtimenosee.logic.commands.PolicyDeleteAssignedCommand;
 import longtimenosee.logic.parser.exceptions.ParseException;
 
 /**
  * Parses input arguments and creates a new PolicyDeleteCommand object
  */
-public class PolicyDeleteCommandParser implements Parser<PolicyDeleteCommand> {
+public class PolicyAssignedDeleteCommandParser implements Parser<PolicyDeleteAssignedCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the PolicyDeleteCommand
      * and returns a DeleteCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public PolicyDeleteCommand parse(String args) throws ParseException {
+    public PolicyDeleteAssignedCommand parse(String args) throws ParseException {
+
+        Index personIndex;
+        Index policyIndex;
+
         try {
-            Index index = ParserUtil.parseIndex(args);
-            return new PolicyDeleteCommand(index);
+            String trimmedInput = args.trim();
+            String[] indexes = (trimmedInput.split(" "));
+            personIndex = ParserUtil.parseIndex(indexes[0]);
+            policyIndex = ParserUtil.parseIndex(indexes[1]);
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PolicyDeleteCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    PolicyDeleteAssignedCommand.MESSAGE_USAGE), pe);
         }
+        return new PolicyDeleteAssignedCommand(personIndex, policyIndex);
     }
 
 }

--- a/src/main/java/longtimenosee/logic/parser/PolicyAssignedListCommandParser.java
+++ b/src/main/java/longtimenosee/logic/parser/PolicyAssignedListCommandParser.java
@@ -1,0 +1,29 @@
+package longtimenosee.logic.parser;
+
+import static longtimenosee.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import longtimenosee.commons.core.index.Index;
+import longtimenosee.logic.commands.PolicyDeleteCommand;
+import longtimenosee.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new PolicyDeleteCommand object
+ */
+public class PolicyDeleteCommandParser implements Parser<PolicyDeleteCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the PolicyDeleteCommand
+     * and returns a DeleteCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public PolicyDeleteCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new PolicyDeleteCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PolicyDeleteCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/longtimenosee/logic/parser/PolicyAssignedListCommandParser.java
+++ b/src/main/java/longtimenosee/logic/parser/PolicyAssignedListCommandParser.java
@@ -1,28 +1,29 @@
 package longtimenosee.logic.parser;
 
-import static longtimenosee.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import longtimenosee.commons.core.index.Index;
+import longtimenosee.logic.commands.PolicyAssignedListCommand;
 import longtimenosee.logic.commands.PolicyDeleteCommand;
 import longtimenosee.logic.parser.exceptions.ParseException;
+
+import static longtimenosee.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 /**
  * Parses input arguments and creates a new PolicyDeleteCommand object
  */
-public class PolicyDeleteCommandParser implements Parser<PolicyDeleteCommand> {
+public class PolicyAssignedListCommandParser implements Parser<PolicyAssignedListCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the PolicyDeleteCommand
      * and returns a DeleteCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public PolicyDeleteCommand parse(String args) throws ParseException {
+    public PolicyAssignedListCommand parse(String args) throws ParseException {
         try {
             Index index = ParserUtil.parseIndex(args);
-            return new PolicyDeleteCommand(index);
+            return new PolicyAssignedListCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PolicyDeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PolicyAssignedListCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/longtimenosee/logic/parser/PolicyAssignedListCommandParser.java
+++ b/src/main/java/longtimenosee/logic/parser/PolicyAssignedListCommandParser.java
@@ -1,11 +1,10 @@
 package longtimenosee.logic.parser;
 
+import static longtimenosee.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 import longtimenosee.commons.core.index.Index;
 import longtimenosee.logic.commands.PolicyAssignedListCommand;
-import longtimenosee.logic.commands.PolicyDeleteCommand;
 import longtimenosee.logic.parser.exceptions.ParseException;
-
-import static longtimenosee.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 /**
  * Parses input arguments and creates a new PolicyDeleteCommand object

--- a/src/main/java/longtimenosee/model/AddressBook.java
+++ b/src/main/java/longtimenosee/model/AddressBook.java
@@ -23,7 +23,6 @@ public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniquePersonList persons;
     private final UniquePolicyList policies;
-
     private final UniqueEventList events;
 
     /*

--- a/src/main/java/longtimenosee/model/person/Person.java
+++ b/src/main/java/longtimenosee/model/person/Person.java
@@ -147,6 +147,10 @@ public class Person {
         return assignedPolicies.add(assignedPolicy);
     }
 
+    public boolean removePolicy(AssignedPolicy assignedPolicy) {
+        return assignedPolicies.remove(assignedPolicy);
+    }
+
     public Birthday getBirthday() {
         return this.birthday;
     }

--- a/src/main/java/longtimenosee/model/policy/AssignedPolicy.java
+++ b/src/main/java/longtimenosee/model/policy/AssignedPolicy.java
@@ -67,6 +67,10 @@ public class AssignedPolicy {
         return this.endDate;
     }
 
+    public boolean isSamePolicy(Policy policyToCheck) {
+        return this.policy.isSamePolicy(policyToCheck);
+    }
+
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder();

--- a/src/main/java/longtimenosee/ui/MainWindow.java
+++ b/src/main/java/longtimenosee/ui/MainWindow.java
@@ -229,7 +229,7 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
-            if (commandResult.isShowClient()) {
+            if (commandResult.isShowPerson()) {
                 updateInnerContent("client");
             }
 

--- a/src/test/java/longtimenosee/logic/LogicManagerTest.java
+++ b/src/test/java/longtimenosee/logic/LogicManagerTest.java
@@ -62,7 +62,7 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-        String deleteCommand = "delete 9";
+        String deleteCommand = "deleteContact 9";
         assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 


### PR DESCRIPTION
New commands added:

1. deletePolicy (index of Policy)
- Command also deletes all corresponding assigned policies in relevant persons.

2. deleteAssigned (index of person) (index of assignedPolicy)

3. listAssigned (index of person)
- Lists assigned policies in CLI